### PR TITLE
Fix: Resolve sensors showing unknown state

### DIFF
--- a/custom_components/marstek_ble/coordinator.py
+++ b/custom_components/marstek_ble/coordinator.py
@@ -226,6 +226,9 @@ class MarstekDataUpdateCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
 
     async def _poll_medium(self) -> None:
         """Poll medium-update data (system, WiFi, config, etc)."""
+        # Device info (type, ID, MAC, firmware version)
+        await self._send_and_sleep(CMD_DEVICE_INFO)
+
         # System data
         await self._send_and_sleep(CMD_SYSTEM_DATA)
 

--- a/custom_components/marstek_ble/sensor.py
+++ b/custom_components/marstek_ble/sensor.py
@@ -225,40 +225,6 @@ async def async_setup_entry(
             SensorDeviceClass.TEMPERATURE,
             SensorStateClass.MEASUREMENT,
         ),
-        # Diagnostic sensors
-        MarstekSensor(
-            coordinator,
-            entry,
-            "system_status",
-            "System Status",
-            lambda data: data.system_status,
-            None,
-            None,
-            SensorStateClass.MEASUREMENT,
-            entity_category=EntityCategory.DIAGNOSTIC,
-        ),
-        MarstekSensor(
-            coordinator,
-            entry,
-            "config_mode",
-            "Config Mode",
-            lambda data: data.config_mode,
-            None,
-            None,
-            SensorStateClass.MEASUREMENT,
-            entity_category=EntityCategory.DIAGNOSTIC,
-        ),
-        MarstekSensor(
-            coordinator,
-            entry,
-            "ct_polling_rate",
-            "CT Polling Rate",
-            lambda data: data.ct_polling_rate,
-            None,
-            None,
-            SensorStateClass.MEASUREMENT,
-            entity_category=EntityCategory.DIAGNOSTIC,
-        ),
     ]
 
     # Add cell voltage sensors
@@ -298,6 +264,30 @@ async def async_setup_entry(
                     and data.battery_voltage * data.battery_current < -5
                     else "inactive"
                 ),
+            ),
+            MarstekTextSensor(
+                coordinator,
+                entry,
+                "system_status",
+                "System Status",
+                lambda data: f"0x{data.system_status:02X}" if data.system_status is not None else None,
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+            MarstekTextSensor(
+                coordinator,
+                entry,
+                "config_mode",
+                "Config Mode",
+                lambda data: f"0x{data.config_mode:02X}" if data.config_mode is not None else None,
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+            MarstekTextSensor(
+                coordinator,
+                entry,
+                "ct_polling_rate",
+                "CT Polling Rate",
+                lambda data: f"{data.ct_polling_rate}s" if data.ct_polling_rate is not None else None,
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
             MarstekTextSensor(
                 coordinator,


### PR DESCRIPTION
This commit fixes the issue where several sensors were showing "unknown" values:

1. Add CMD_DEVICE_INFO (0x04) to medium polling schedule
   - This command was missing from the polling cycle
   - Fixes device_type, device_id, mac_address, and firmware_version sensors

2. Convert diagnostic sensors from numeric to text format
   - system_status: now displays as hex (e.g., "0x61")
   - config_mode: now displays as hex (e.g., "0x61")
   - ct_polling_rate: now displays with units (e.g., "5s")

3. Remove inappropriate SensorStateClass.MEASUREMENT from diagnostic sensors
   - These sensors represent status/config values, not measurements

The remaining sensors (adaptive_power_out, wifi_ssid, network_info, meter_ip, local_api_status) should populate once their commands receive responses from the device during polling.